### PR TITLE
Upgrade marisa-trie for compatibility with Python 3.11+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version 2.0 (2024-??-??)
+
+- Update `marisa-trie` for compatibility with Python 3.11+
+    - **This update changes the minimum compatible Python version of this package to Python 3.7**
+- Replace usage of `pkg_resources.resource_filename` with `importlib_resources.files` as `pkg_resources` has been deprecated.
+
 # Version 1.1 (2021-??-??)
 
 - Updated to CLDR v40.

--- a/language_data/util.py
+++ b/language_data/util.py
@@ -2,14 +2,11 @@
 Used for locating a file in the data directory.
 """
 
-from pkg_resources import resource_filename
-DATA_ROOT = resource_filename('language_data', 'data')
-import os
-
+from importlib.resources import files
 
 def data_filename(filename):
     """
     Given a relative filename, get the full path to that file in the data
     directory.
     """
-    return os.path.join(DATA_ROOT, filename)
+    return files('language_data') / 'data' / filename

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,8 @@ include = ["language_data/data", "CHANGELOG.md"]
 exclude = ["language_data/data/cldr", "language_data/data/cldr-json"]
 
 [tool.poetry.dependencies]
-python = ">= 3.6"
-marisa-trie = "^0.7.7"
+python = ">= 3.7"
+marisa-trie = ">=1.1.0"
 
 [tool.poetry.dev-dependencies]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "language_data"
-version = "1.1"
+version = "2.0"
 description = "Supplementary data about languages used by the langcodes module"
 authors = ["Elia Robyn Speer <rspeer@arborelia.net>"]
 license = "MIT"


### PR DESCRIPTION
- Bump version to `2.0` as this change ends support for Python 3.6
- prevent deprecation warnings from `pkg_resources.resource_filename` usage
